### PR TITLE
Added Power Effect Description to Chat Template, Changed Handling for Miracles, Fixed Initiative Bug

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -65,6 +65,7 @@
   "CHAT.DAMAGE": "Damage",
   "CHAT.TRAITS": "Traits",
   "CHAT.OVERCAST": "Overcast",
+  "CHAT.EFFECT": "Effect",
 
   "CONNECTION.NAME": "Name",
   "CONNECTION.DESCRIPTION": "Description",

--- a/lang/en.json
+++ b/lang/en.json
@@ -60,6 +60,7 @@
   "CATEGORY.RANGE": "Range",
 
   "CHAT.SUCCEED": "Succeed with",
+  "CHAT.SUCCESS": "additional successes",
   "CHAT.FAILED": "Failed, missing",
   "CHAT.FOCUS": "Focus",
   "CHAT.DAMAGE": "Damage",

--- a/lang/en.json
+++ b/lang/en.json
@@ -59,7 +59,7 @@
   "CATEGORY.MELEE": "Melee",
   "CATEGORY.RANGE": "Range",
 
-  "CHAT.SUCCEED": "Succeed with",
+  "CHAT.SUCCEED": "Succeeded with",
   "CHAT.SUCCESS": "additional successes",
   "CHAT.FAILED": "Failed, missing",
   "CHAT.FOCUS": "Focus",
@@ -67,7 +67,7 @@
   "CHAT.TRAITS": "Traits",
   "CHAT.OVERCAST": "Overcast",
   "CHAT.EFFECT": "Effect",
-  "CHAT.RESIST": "Resist",
+  "CHAT.RESIST": "Test",
   "CHAT.DURATION": "Duration",
 
   "CONNECTION.NAME": "Name",
@@ -273,7 +273,7 @@
   "WEAPON.COST": "Cost",
 
   "WOUND.NAME": "Name",
-  "WOUND.DAMAGE": "Damage",
+  "WOUND.DAMAGE": "Wounds",
   "WOUND.DESCRIPTION": "Description"
   
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -66,6 +66,7 @@
   "CHAT.TRAITS": "Traits",
   "CHAT.OVERCAST": "Overcast",
   "CHAT.EFFECT": "Effect",
+  "CHAT.RESIST": "Resist",
 
   "CONNECTION.NAME": "Name",
   "CONNECTION.DESCRIPTION": "Description",
@@ -152,7 +153,7 @@
   "POWER.DURATION": "Duration",
   "POWER.EFFECT": "Effect",
 
-  "RANGE.YOU": "You",
+  "RANGE.SPECIAL": "Special",
   "RANGE.SELF": "Self",
   "RANGE.CLOSE": "Close",
   "RANGE.SHORT": "Short",

--- a/lang/en.json
+++ b/lang/en.json
@@ -67,6 +67,7 @@
   "CHAT.OVERCAST": "Overcast",
   "CHAT.EFFECT": "Effect",
   "CHAT.RESIST": "Resist",
+  "CHAT.DURATION": "Duration",
 
   "CONNECTION.NAME": "Name",
   "CONNECTION.DESCRIPTION": "Description",
@@ -273,4 +274,5 @@
   "WOUND.NAME": "Name",
   "WOUND.DAMAGE": "Damage",
   "WOUND.DESCRIPTION": "Description"
+  
 }

--- a/scripts/common/hooks.js
+++ b/scripts/common/hooks.js
@@ -19,7 +19,7 @@ import { initializeHandlebars } from "./handlebars.js";
 import { prepareCustomRoll } from "./dialog.js";
 
 Hooks.once("init", () => {
-    game.settings.register("age-of-sigmar", "initiativeRule", {
+    game.settings.register("age-of-sigmar-soulbound", "initiativeRule", {
         name: "SETTING.INIT_RULE",
         hint: "SETTING.INIT_HINT",
         scope: "world",
@@ -46,22 +46,22 @@ Hooks.once("init", () => {
     CONFIG.fontFamilies.push("Alegreya Sans SC");
     CONFIG.roll = prepareCustomRoll;
     Actors.unregisterSheet("core", ActorSheet);
-    Actors.registerSheet("age-of-sigmar", PlayerSheet, { types: ["player"], makeDefault: true });
-    Actors.registerSheet("age-of-sigmar", NpcSheet, { types: ["npc"], makeDefault: true });
-    Actors.registerSheet("age-of-sigmar", PartySheet, { types: ["party"], makeDefault: true });
+    Actors.registerSheet("age-of-sigmar-soulbound", PlayerSheet, { types: ["player"], makeDefault: true });
+    Actors.registerSheet("age-of-sigmar-soulbound", NpcSheet, { types: ["npc"], makeDefault: true });
+    Actors.registerSheet("age-of-sigmar-soulbound", PartySheet, { types: ["party"], makeDefault: true });
     Items.unregisterSheet("core", ItemSheet);
-    Items.registerSheet("age-of-sigmar", AethericDeviceSheet, { types: ["aethericDevice"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", ArmourSheet, { types: ["armour"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", ConnectionSheet, { types: ["connection"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", EquipmentSheet, { types: ["equipment"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", GoalSheet, { types: ["goal"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", MiracleSheet, { types: ["miracle"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", PartyItemSheet, { types: ["ally", "enemy", "fear", "resource", "rumour", "threat"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", RuneSheet, { types: ["rune"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", SpellSheet, { types: ["spell"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", TalentSheet, { types: ["talent"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", WeaponSheet, { types: ["weapon"], makeDefault: true });
-    Items.registerSheet("age-of-sigmar", WoundSheet, { types: ["wound"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", AethericDeviceSheet, { types: ["aethericDevice"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", ArmourSheet, { types: ["armour"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", ConnectionSheet, { types: ["connection"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", EquipmentSheet, { types: ["equipment"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", GoalSheet, { types: ["goal"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", MiracleSheet, { types: ["miracle"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", PartyItemSheet, { types: ["ally", "enemy", "fear", "resource", "rumour", "threat"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", RuneSheet, { types: ["rune"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", SpellSheet, { types: ["spell"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", TalentSheet, { types: ["talent"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", WeaponSheet, { types: ["weapon"], makeDefault: true });
+    Items.registerSheet("age-of-sigmar-soulbound", WoundSheet, { types: ["wound"], makeDefault: true });
     initializeHandlebars();
 });
 

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -34,7 +34,7 @@ export async function powerRoll(attribute, skill, power, dn) {
 		duration = power.data.data.duration;
 		resist = power.data.data.test;
 		if(resist !== null && result.success.length > 0) {
-			resist = resist.replace(/:s/ig, ":" + result.success.length);
+			resist = resist.replace(/:s/ig, ":" + result.success.length - dn.complexity + 1);
 		}
 	}
     await _sendSpellToChat(result, dn, skill.focus, duration, overcast, effect, resist);
@@ -61,9 +61,9 @@ async function _sendSpellToChat(result, dn, focus, duration, overcast, effect, r
     const dices = result.success.concat(result.failed);
     const data = {
         hasSucceed: result.success.length >= dn.complexity,
-        success: result.success.length,
+        success: result.success.length - dn.complexity, // show additional degrees instead of raw success
         missing: dn.complexity - result.success.length,
-        failed: result.failed.length,
+        failed: result.failed.length ,
         dices: dices.sort(function (a, b) { return b - a; }),
         dn: dn,
         focus: focus,

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -25,14 +25,14 @@ export async function combatRoll(attribute, skill, combat, dn) {
 export async function powerRoll(attribute, skill, power, dn) {
     const numberOfDice = attribute.total + skill.total;
     let result = _roll(numberOfDice, dn);
-    let overcast;
 	let effect = power.data.data.effect;
 	let resist;
+	let overcast;
     if (power.type === "spell") {
         overcast = power.data.data.overcast;
 		resist = power.data.data.test;
 		if(resist !== null && result.success.length > 0) {
-			resist = resist.replace("/:s/ig", ":" + result.success.length);
+			resist = resist.replace(/:s/ig, ":" + result.success.length);
 		}
     } else {
         overcast = null;

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -31,7 +31,7 @@ export async function powerRoll(attribute, skill, power, dn) {
     if (power.type === "spell") {
         overcast = power.data.data.overcast;
 		resist = power.data.data.test;
-		if(result.success.length > 0) {
+		if(resist !== null && result.success.length > 0) {
 			resist = resist.replace("/:s/ig", ":" + result.success.length);
 		}
     } else {

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -1,12 +1,12 @@
 export async function customRoll(pool, dn) {
     let result = _roll(pool, dn);
-    await _sendToChat(result, dn, 0, null, null, null, null);
+    await _sendToChat(result, dn, 0, null, null, null, null, null);
 }
 
 export async function commonRoll(attribute, skill, dn) {
     const numberOfDice = attribute.total + skill.total;
     let result = _roll(numberOfDice, dn);
-    await _sendToChat(result, dn, skill.focus, null, null, null, null);
+    await _sendToChat(result, dn, skill.focus, null, null, null, null, null);
 }
 
 export async function combatRoll(attribute, skill, combat, dn) {
@@ -19,20 +19,26 @@ export async function combatRoll(attribute, skill, combat, dn) {
     } else {
         damage = weapon.damage - combat.armour;
     }
-    await _sendToChat(result, dn, skill.focus, damage, weapon.traits, null, null);
+    await _sendToChat(result, dn, skill.focus, damage, weapon.traits, null, null, null);
 }
 
 export async function powerRoll(attribute, skill, power, dn) {
     const numberOfDice = attribute.total + skill.total;
     let result = _roll(numberOfDice, dn);
     let overcast;
-	let effect = power.data.data.effect
+	let effect = power.data.data.effect;
+	let resist;
     if (power.type === "spell") {
         overcast = power.data.data.overcast;
+		resist = power.data.data.test;
+		if(result.success.length > 0) {
+			resist = resist.replace("/:s/ig", ":" + result.success.length);
+		}
     } else {
-        overcast = null
+        overcast = null;
+		resist = null;
     }
-    await _sendToChat(result, dn, skill.focus, null, null, overcast, effect);
+    await _sendToChat(result, dn, skill.focus, null, null, overcast, effect, resist);
 }
 
 function _roll(numberOfDice, dn) {
@@ -52,7 +58,7 @@ function _roll(numberOfDice, dn) {
     return result;
 }
 
-async function _sendToChat(result, dn, focus, damage, traits, overcast, effect) {
+async function _sendToChat(result, dn, focus, damage, traits, overcast, effect, resist) {
     const dices = result.success.concat(result.failed);
     const data = {
         hasSucceed: result.success.length >= dn.complexity,
@@ -63,6 +69,7 @@ async function _sendToChat(result, dn, focus, damage, traits, overcast, effect) 
         dn: dn,
         focus: focus,
 		effect: effect,
+		resist: resist,
         damage: damage,
         traits: traits,
         overcast: overcast

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -33,8 +33,9 @@ export async function powerRoll(attribute, skill, power, dn) {
         overcast = power.data.data.overcast;
 		duration = power.data.data.duration;
 		resist = power.data.data.test;
-		if(resist !== null && result.success.length > 0) {
-			resist = resist.replace(/:s/ig, ":" + result.success.length - dn.complexity + 1);
+		let complexity = result.success.length - dn.complexity +1
+		if(resist !== null && complexity > 0) {
+			resist = resist.replace(/:s/ig, ":" + complexity);
 		}
 	}
     await _sendSpellToChat(result, dn, skill.focus, duration, overcast, effect, resist);

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -1,12 +1,12 @@
 export async function customRoll(pool, dn) {
     let result = _roll(pool, dn);
-    await _sendToChat(result, dn, 0, null, null, null);
+    await _sendToChat(result, dn, 0, null, null, null, null);
 }
 
 export async function commonRoll(attribute, skill, dn) {
     const numberOfDice = attribute.total + skill.total;
     let result = _roll(numberOfDice, dn);
-    await _sendToChat(result, dn, skill.focus, null, null, null);
+    await _sendToChat(result, dn, skill.focus, null, null, null, null);
 }
 
 export async function combatRoll(attribute, skill, combat, dn) {
@@ -19,19 +19,20 @@ export async function combatRoll(attribute, skill, combat, dn) {
     } else {
         damage = weapon.damage - combat.armour;
     }
-    await _sendToChat(result, dn, skill.focus, damage, weapon.traits, null);
+    await _sendToChat(result, dn, skill.focus, damage, weapon.traits, null, null);
 }
 
 export async function powerRoll(attribute, skill, power, dn) {
     const numberOfDice = attribute.total + skill.total;
     let result = _roll(numberOfDice, dn);
     let overcast;
+	let effect = power.data.data.effect
     if (power.type === "spell") {
         overcast = power.data.data.overcast;
     } else {
         overcast = null
     }
-    await _sendToChat(result, dn, skill.focus, null, null, overcast);
+    await _sendToChat(result, dn, skill.focus, null, null, overcast, effect);
 }
 
 function _roll(numberOfDice, dn) {
@@ -51,7 +52,7 @@ function _roll(numberOfDice, dn) {
     return result;
 }
 
-async function _sendToChat(result, dn, focus, damage, traits, overcast) {
+async function _sendToChat(result, dn, focus, damage, traits, overcast, effect) {
     const dices = result.success.concat(result.failed);
     const data = {
         hasSucceed: result.success.length >= dn.complexity,
@@ -61,6 +62,7 @@ async function _sendToChat(result, dn, focus, damage, traits, overcast) {
         dices: dices.sort(function (a, b) { return b - a; }),
         dn: dn,
         focus: focus,
+		effect: effect,
         damage: damage,
         traits: traits,
         overcast: overcast

--- a/scripts/sheet/actor.js
+++ b/scripts/sheet/actor.js
@@ -12,6 +12,7 @@ export class AgeOfSigmarActorSheet extends ActorSheet {
         html.find(".roll-skill").click(async ev => await this._prepareRollSkill(ev));
         html.find(".roll-weapon").click(async ev => await this._prepareRollWeapon(ev));
         html.find(".roll-power").click(async ev => await this._prepareRollPower(ev));
+		html.find(".show-power").click(async ev => await this._prepareShowPower(ev));
     }
 
     _getHeaderButtons() {
@@ -122,6 +123,13 @@ export class AgeOfSigmarActorSheet extends ActorSheet {
             skills = this._setSelectedSkill("devotion")
         }
         await preparePowerRoll(attributes, skills, power);
+    }
+	
+	async _prepareShowPower(event) {
+        event.preventDefault();
+        const div = $(event.currentTarget).parents(".item");
+        const power = this.actor.getOwnedItem(div.data("itemId"));
+        await power.sendToChat()
     }
 
     _setSelectedAttribute(attributeName) {

--- a/style/common/variable.css
+++ b/style/common/variable.css
@@ -6,7 +6,6 @@
 @font-face {
     font-family: "Alegreya Sans SC";
     src: url("../../asset/font/alegreya-sans-sc-bold.ttf");
-    font-weight: bold;
 }
 
 :root {

--- a/style/common/variable.css
+++ b/style/common/variable.css
@@ -6,6 +6,7 @@
 @font-face {
     font-family: "Alegreya Sans SC";
     src: url("../../asset/font/alegreya-sans-sc-bold.ttf");
+	font-weight: bold;
 }
 
 :root {

--- a/system.json
+++ b/system.json
@@ -4,9 +4,9 @@
   "description": "Perilous adventures in the mortal realms",
   "version": "2.3.0",
   "minimumCoreVersion": "0.7.5",
-  "compatibleCoreVersion": "0.7.5",
+  "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
-  "author": "Moo Man, Perfectro",
+  "author": "Moo Man, Perfectro, Vendare",
   "scripts": [],
   "esmodules": [
     "scripts/common/hooks.js"

--- a/template/chat/roll.html
+++ b/template/chat/roll.html
@@ -10,6 +10,9 @@
         {{#if focus}}
         <p style="margin-top: 5px"><strong>{{localize "CHAT.FOCUS"}} :</strong> {{focus}}</p>
         {{/if}}
+		{{#if effect}}
+        <p style="margin-top: 5px"><strong>{{localize "CHAT.EFFECT"}} :</strong> {{effect}}</p>
+        {{/if}}
         {{#if damage}}
         <p style="margin-top: 5px"><strong>{{localize "CHAT.DAMAGE"}} :</strong> {{damage}}</p>
         {{/if}}

--- a/template/chat/roll.html
+++ b/template/chat/roll.html
@@ -13,6 +13,9 @@
 		{{#if effect}}
         <p style="margin-top: 5px"><strong>{{localize "CHAT.EFFECT"}} :</strong> {{effect}}</p>
         {{/if}}
+		{{#if resist}}
+        <p style="margin-top: 5px"><strong>{{localize "CHAT.RESIST"}} :</strong> {{resist}}</p>
+        {{/if}}
         {{#if damage}}
         <p style="margin-top: 5px"><strong>{{localize "CHAT.DAMAGE"}} :</strong> {{damage}}</p>
         {{/if}}

--- a/template/chat/roll.html
+++ b/template/chat/roll.html
@@ -2,7 +2,7 @@
     <div class="wrapper">
         <h3>{{dn.name}} DN {{dn.difficulty}}:{{dn.complexity}}</h3>
         {{#if hasSucceed}}
-        <h4 style="color: var(--color-succeed)">{{localize "CHAT.SUCCEED"}} <strong>{{success}}</strong></h4>
+        <h4 style="color: var(--color-succeed)">{{localize "CHAT.SUCCEED"}} <strong>{{success}}</strong> {{localize "CHAT.SUCCESS"}}</h4>
         {{else}}
         <h4 style="color: var(--color-deadly)">{{localize "CHAT.FAILED"}} <strong>{{missing}}</strong></h4>
         {{/if}}

--- a/template/chat/spellRoll.html
+++ b/template/chat/spellRoll.html
@@ -6,17 +6,22 @@
         {{else}}
         <h4 style="color: var(--color-deadly)">{{localize "CHAT.FAILED"}} <strong>{{missing}}</strong></h4>
         {{/if}}
-
         {{#if focus}}
         <p style="margin-top: 5px"><strong>{{localize "CHAT.FOCUS"}} :</strong> {{focus}}</p>
         {{/if}}
-        {{#if damage}}
-        <p style="margin-top: 5px"><strong>{{localize "CHAT.DAMAGE"}} :</strong> {{damage}}</p>
+		{{#if effect}}
+        <p style="margin-top: 5px"><strong>{{localize "CHAT.EFFECT"}} :</strong> {{effect}}</p>
         {{/if}}
-        {{#if traits}}
-        <p style="margin-top: 5px"><strong>{{localize "CHAT.TRAITS"}} :</strong> {{traits}}</p>
+		{{#if duration}}
+        <p style="margin-top: 5px"><strong>{{localize "CHAT.DURATION"}} :</strong> {{duration}}</p>
         {{/if}}
-		
+		{{#if resist}}
+        <p style="margin-top: 5px"><strong>{{localize "CHAT.RESIST"}} :</strong> {{resist}}</p>
+        {{/if}}
+        {{#if overcast}}
+        <p style="margin-top: 5px"><strong>{{localize "CHAT.OVERCAST"}} :</strong> {{overcast}}</p>
+        {{/if}}
+
         {{#each dices as |dice|}}
             <img width='25px' height='25px' style='border:none;margin-right:2px;margin-top:2px' src='systems/age-of-sigmar-soulbound/asset/image/dice-{{dice}}.png'/>
         {{/each}}

--- a/template/chat/spellRoll.html
+++ b/template/chat/spellRoll.html
@@ -2,7 +2,7 @@
     <div class="wrapper">
         <h3>{{dn.name}} DN {{dn.difficulty}}:{{dn.complexity}}</h3>
         {{#if hasSucceed}}
-        <h4 style="color: var(--color-succeed)">{{localize "CHAT.SUCCEED"}} <strong>{{success}}</strong></h4>
+        <h4 style="color: var(--color-succeed)">{{localize "CHAT.SUCCEED"}} <strong>{{success}}</strong> {{localize "CHAT.SUCCESS"}}</h4>
         {{else}}
         <h4 style="color: var(--color-deadly)">{{localize "CHAT.FAILED"}} <strong>{{missing}}</strong></h4>
         {{/if}}

--- a/template/sheet/spell.html
+++ b/template/sheet/spell.html
@@ -43,7 +43,7 @@
                         <label>{{localize "SPELL.RANGE"}}</label>
                         <select name="data.range">
                             {{#select data.range}}
-                                <option value="you">{{localize "RANGE.YOU"}}</option>
+                                <option value="special">{{localize "RANGE.SPECIAL"}}</option>
                                 <option value="self">{{localize "RANGE.SELF"}}</option>
                                 <option value="close">{{localize "RANGE.CLOSE"}}</option>
                                 <option value="short">{{localize "RANGE.SHORT"}}</option>

--- a/template/sheet/tab/player-combat.html
+++ b/template/sheet/tab/player-combat.html
@@ -157,7 +157,11 @@
                         <div class="image-container">
                             <div class="image" style="background-image: url('{{item.img}}')"></div>
                         </div>
+						{{#if item.isSpell}}
                         <div class="roll-power">{{item.name}}</div>
+						{{else}}
+						<div class="show-power">{{item.name}}</div>
+						{{/if}}
                     </div>
                     {{#if item.isSpell}}
                     <div class="dn">{{item.data.dn}}</div>


### PR DESCRIPTION
It doesn't help that when casting spells nothing is shown but it's name and overcast conditions. For Damage and Specifics one has to check the book or ingame item for clarification. This hinders game flow so i added the effect field to the roll template. Now when rolling for the spell what was put into the effects field is printed above the overcast conditions eliminating the need to read up on spell effects mid combat.

Certain spells can be resisted. For this the field "test" in the spell item is read out. In the result string the target number notation is case insensitively replaced with the number of successes on the test prefixed by a colon. 

Also Miracles work differently from Spells. A roll isn't always needed and it effects vary heavily. Clicking on miracle in the combat tab sends it to chat instead of making a possibly unnecessary roll

Initiative and its corresponding Gamesystem Setting didn't work because it was not correctly registered in the hook.js script. The registration key differed from the gamesystem identifier.

Keeping a one - size fits all chat template for rolls would have gotten messy as features are added thus i added a template for spells that is filled seperately from other rolls.

Additional Successes are easily calculated so instead of listing the total result count for each test it now, shows additional successes on the success line of the template