### PR TITLE
Bugfixes and new Combat Dialog

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -83,7 +83,10 @@
   "DIALOG.COMMON_ROLL": "Common Roll",
   "DIALOG.CUSTOM_ROLL": "Custom Roll",
   "DIALOG.DOUBLE_TRAINING": "Double Your Training",
-
+  "DIALOG.DEFENSE": "Target Defense",
+  "DIALOG.ARMOUR" : "Target Armour",
+  "DIALOG.BONUSDICE" : "Bonus Dice",
+  
   "EQUIPMENT.NAME": "Name",
   "EQUIPMENT.COST": "Cost",
   "EQUIPMENT.AVAILABILITY": "Availability",

--- a/lang/en.json
+++ b/lang/en.json
@@ -40,6 +40,7 @@
   "BIO.SPECIES": "Species",
   "BIO.AGE": "Age",
   "BIO.EYES": "Eyes",
+  "BIO.EYETYPE": "Eyetype",
   "BIO.HAIR": "Hair",
   "BIO.HEIGHT": "Height",
   "BIO.WEIGHT": "Weight",

--- a/lang/en.json
+++ b/lang/en.json
@@ -59,7 +59,7 @@
   "CATEGORY.MELEE": "Melee",
   "CATEGORY.RANGE": "Range",
 
-  "CHAT.SUCCEED": "Succeed with",
+  "CHAT.SUCCEED": "Succeeded with",
   "CHAT.SUCCESS": "additional successes",
   "CHAT.FAILED": "Failed, missing",
   "CHAT.FOCUS": "Focus",
@@ -67,7 +67,7 @@
   "CHAT.TRAITS": "Traits",
   "CHAT.OVERCAST": "Overcast",
   "CHAT.EFFECT": "Effect",
-  "CHAT.RESIST": "Resist",
+  "CHAT.RESIST": "Test",
   "CHAT.DURATION": "Duration",
 
   "CONNECTION.NAME": "Name",
@@ -273,7 +273,7 @@
   "WEAPON.COST": "Cost",
 
   "WOUND.NAME": "Name",
-  "WOUND.DAMAGE": "Damage",
+  "WOUND.DAMAGE": "Wounds",
   "WOUND.DESCRIPTION": "Description"
   
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -168,7 +168,8 @@
   "SETTING.INIT_RULE": "Initiative Rules",
   "SETTING.INIT_HINT": "Configure which method is used to determine who acts first in combat.",
   "SETTING.INIT_DEFAULT": "Highest to Lowest Initative",
-  "SETTING.INIT_ROLL": "Roll 2d6 + Initiative, higher go first",
+  "SETTING.INIT_ROLL2d": "Roll 2d6 + Initiative, higher go first",
+  "SETTING.INIT_ROLL1d": "Roll 1d6 + Initiative, higher go first",
 
   "SKILL.ARCANA": "Arcana",
   "SKILL.ATHLETICS": "Athletics",

--- a/scripts/common/actor.js
+++ b/scripts/common/actor.js
@@ -144,7 +144,8 @@ export class AgeOfSigmarActor extends Actor {
 
     _computeArmour(data, item) {
         if (item.data.type === "shield") {
-            data.data.combat.defense.total += item.data.benefit;
+            // Like below treat shield benefit as an step increase
+            data.data.combat.defense.total += (item.data.benefit * 2);
         } else {
             data.data.combat.armour.total += item.data.benefit;
         }
@@ -170,6 +171,7 @@ export class AgeOfSigmarActor extends Actor {
     }
 
     _computeSecondary(data) {
+        // melee, accuracy and defense bonus is doubled to represent a one step increase
         data.data.combat.melee.total += data.data.attributes.body.value + data.data.skills.weaponSkill.total + (data.data.combat.melee.bonus * 2);
         data.data.combat.accuracy.total += data.data.attributes.mind.value + data.data.skills.ballisticSkill.total + (data.data.combat.accuracy.bonus * 2);
         data.data.combat.defense.total += data.data.attributes.body.total + data.data.skills.reflexes.total + (data.data.combat.defense.bonus * 2);

--- a/scripts/common/actor.js
+++ b/scripts/common/actor.js
@@ -7,6 +7,7 @@ export class AgeOfSigmarActor extends Actor {
             this._computeItems(this.data);
             this._computeAttack(this.data);
             this._computeSecondary(this.data);
+            this._computeRelativeCombatAbilities(this.data);
         } else if (this.data.type === "party") {
             this._computePartyItems(this.data);
         }
@@ -17,8 +18,11 @@ export class AgeOfSigmarActor extends Actor {
         data.data.attributes.mind.total = data.data.attributes.mind.value;
         data.data.attributes.soul.total = data.data.attributes.soul.value;
         data.data.combat.melee.total = 0;
+        data.data.combat.melee.relative = 0;
         data.data.combat.accuracy.total = 0;
+        data.data.combat.accuracy.relative = 0;
         data.data.combat.defense.total = 0;
+        data.data.combat.defense.relative = 0;
         data.data.combat.armour.total = 0;
         data.data.combat.health.toughness.max = 0;
         data.data.combat.health.wounds.value = 0;
@@ -31,6 +35,33 @@ export class AgeOfSigmarActor extends Actor {
             consumed: 0,
             capacity: 0,
             isUndercharge: false
+        }
+    }
+
+    _computeRelativeCombatAbilities(data) {
+        let combatStat = data.data.combat.melee.total
+        data.data.combat.melee.relative = this._getCombatLadderValue(combatStat);
+
+        combatStat = data.data.combat.accuracy.total
+        data.data.combat.accuracy.relative = this._getCombatLadderValue(combatStat);
+
+        combatStat = data.data.combat.defense.total
+        data.data.combat.defense.relative = this._getCombatLadderValue(combatStat);
+    }
+    
+    _getCombatLadderValue(combatStat) {
+        if(combatStat <= 2)
+            return 1;
+        else if(combatStat <= 4) {
+            return 2;
+        } else if(combatStat <= 6) {
+            return 3;
+        } else if(combatStat <= 8) {
+            return 4;
+        } else if(combatStat <= 10) {
+            return 5;
+        } else {
+            return 6;
         }
     }
 
@@ -128,24 +159,25 @@ export class AgeOfSigmarActor extends Actor {
         data.data.skills.weaponSkill.total += skills.weaponSkill;
     }
 
-    _computeCombat(data, combat) {
-        data.data.combat.mettle.total += combat.mettle;
-        data.data.combat.health.toughness.max += combat.health.toughness;
-        data.data.combat.health.wounds.max += combat.health.wounds;
+    _computeCombat(data, itemBonus) {
+        data.data.combat.mettle.total += itemBonus.mettle;
+        data.data.combat.health.toughness.max += itemBonus.health.toughness;
+        data.data.combat.health.wounds.max += itemBonus.health.wounds;
         data.data.combat.health.wounds.deadly = data.data.combat.health.wounds.value >= data.data.combat.health.wounds.max;
-        data.data.combat.initiative.total += combat.initiative;
-        data.data.combat.naturalAwareness.total += combat.naturalAwareness;
-        data.data.combat.melee.total += (combat.melee * 2);
-        data.data.combat.accuracy.total += (combat.accuracy * 2);
-        data.data.combat.defense.total += (combat.defense * 2);
-        data.data.combat.armour.total += combat.armour;
-        data.data.combat.damage += combat.damage;
+        data.data.combat.initiative.total += itemBonus.initiative;
+        data.data.combat.naturalAwareness.total += itemBonus.naturalAwareness;
+        data.data.combat.melee.total += (itemBonus.melee * 2);
+        data.data.combat.accuracy.total += (itemBonus.accuracy * 2);
+        data.data.combat.defense.total += (itemBonus.defense * 2);
+        data.data.combat.armour.total += itemBonus.armour;
+        data.data.combat.damage += itemBonus.damage;
     }
 
     _computeArmour(data, item) {
         if (item.data.type === "shield") {
             // Like below treat shield benefit as an step increase
             data.data.combat.defense.total += (item.data.benefit * 2);
+            data.data.combat.defense.relative = this._getCombatLadderValue(data.data.combat.defense.total);
         } else {
             data.data.combat.armour.total += item.data.benefit;
         }

--- a/scripts/common/dialog.js
+++ b/scripts/common/dialog.js
@@ -164,7 +164,7 @@ export async function preparePowerRoll(attributes, skills, power) {
     let data = {
         attributes: attributes,
         skills: skills,
-        dn: dn
+        bonusDice : 0 // some spells or miracles grant bonus dice 
     }
     
     const html = await renderTemplate("systems/age-of-sigmar-soulbound/template/dialog/spell-roll.html", data);

--- a/scripts/common/dialog.js
+++ b/scripts/common/dialog.js
@@ -160,7 +160,7 @@ function _getCombatDn(combat) {
         combat.armour = 0;
         return "4:1";
     } else {
-        let targetDefense = target.actor.data.data.combat.defense.total;
+        let targetDefense = target.actor.data.data.combat.defense.relative;
         let difficulty;
         if (combat.weapon.category === "melee") {
             difficulty = 4 - (combat.melee - targetDefense);

--- a/scripts/common/dialog.js
+++ b/scripts/common/dialog.js
@@ -163,7 +163,7 @@ function _getCombatDn(combat) {
         let targetDefense = target.actor.data.data.combat.defense.total;
         let difficulty;
         if (combat.weapon.category === "melee") {
-            difficulty = 4 - (combat.accuracy - targetDefense);
+            difficulty = 4 - (combat.melee - targetDefense);
         } else {
             difficulty = 4 - (combat.accuracy - targetDefense);
         }

--- a/scripts/common/dialog.js
+++ b/scripts/common/dialog.js
@@ -164,6 +164,7 @@ export async function preparePowerRoll(attributes, skills, power) {
     let data = {
         attributes: attributes,
         skills: skills,
+        dn: dn,
         bonusDice : 0 // some spells or miracles grant bonus dice 
     }
     

--- a/scripts/common/handlebars.js
+++ b/scripts/common/handlebars.js
@@ -49,21 +49,15 @@ function registerHandlebarsHelpers() {
         return text.replace(markup, "");
     });
     Handlebars.registerHelper("combatAbilities", function (value) {
-        if (value <= 2) {
-            return `${game.i18n.localize("ABILITIES.POOR")} (1)`;
-        } else if (value >= 3 && value <= 4) {
-            return `${game.i18n.localize("ABILITIES.AVERAGE")} (2)`;
-        } else if (value >= 5 && value <= 6) {
-            return `${game.i18n.localize("ABILITIES.GOOD")} (3)`;
-        } else if (value >= 7 && value <= 8) {
-            return `${game.i18n.localize("ABILITIES.GREAT")} (4)`;
-        } else if (value >= 9 && value <= 10) {
-            return `${game.i18n.localize("ABILITIES.SUPERB")} (5)`;
-        } else if (value >= 11 && value <= 12) {
-            return `${game.i18n.localize("ABILITIES.EXTRAORDINARY")} (6)`;
-        } else {
-            return `${game.i18n.localize("ABILITIES.EXTRAORDINARY")} (${value})`;
-        }
+      switch(value) {
+          case 1: return `${game.i18n.localize("ABILITIES.POOR")} (1)`; 
+          case 2: return `${game.i18n.localize("ABILITIES.AVERAGE")} (2)`;
+          case 3: return `${game.i18n.localize("ABILITIES.GOOD")} (3)`;
+          case 4: return `${game.i18n.localize("ABILITIES.GREAT")} (4)`;
+          case 5: return `${game.i18n.localize("ABILITIES.SUPERB")} (5)`;
+          case 6: return `${game.i18n.localize("ABILITIES.EXTRAORDINARY")} (6)`;
+          default : return `${game.i18n.localize("ABILITIES.EXTRAORDINARY")} (${value})`;
+      }
     });
     Handlebars.registerHelper("localizeState", function (type) {
         switch (type) {

--- a/scripts/common/hooks.js
+++ b/scripts/common/hooks.js
@@ -32,19 +32,11 @@ Hooks.once("init", () => {
             "roll2d6": "SETTING.INIT_ROLL2d"
         },
         onChange: rule => {
-            switch (rule) {
-                case "default":
-                    CONFIG.Combat.initiative = { formula: "1d0 + @combat.initiative.total", decimals: 0 };
-                    break;
-                case "roll1d6":
-                    CONFIG.Combat.initiative = { formula: "1d6 + @combat.initiative.total", decimals: 0 };
-                    break;
-                case "roll2d6":
-                    CONFIG.Combat.initiative = { formula: "2d6 + @combat.initiative.total", decimals: 0 };
-                    break;
-            }
+            _registerInitiative(rule);
         }
     });
+    _registerInitiative(game.settings.get("age-of-sigmar-soulbound", "initiativeRule"));
+    
     CONFIG.Actor.entityClass = AgeOfSigmarActor;
     CONFIG.Item.entityClass = AgeOfSigmarItem;
     CONFIG.fontFamilies.push("Alegreya Sans SC");
@@ -68,6 +60,20 @@ Hooks.once("init", () => {
     Items.registerSheet("age-of-sigmar-soulbound", WoundSheet, { types: ["wound"], makeDefault: true });
     initializeHandlebars();
 });
+
+function _registerInitiative(rule) {
+    switch (rule) {
+        case "default":
+            CONFIG.Combat.initiative = { formula: "@combat.initiative.total", decimals: 0 };
+            break;
+        case "roll1d6":
+            CONFIG.Combat.initiative = { formula: "1d6 + @combat.initiative.total", decimals: 0 };
+            break;
+        case "roll2d6":
+            CONFIG.Combat.initiative = { formula: "2d6 + @combat.initiative.total", decimals: 0 };
+            break;
+    }    
+}
 
 Hooks.on("preCreateActor", (createData) => {
     mergeObject(createData, {

--- a/scripts/common/hooks.js
+++ b/scripts/common/hooks.js
@@ -28,14 +28,18 @@ Hooks.once("init", () => {
         type: String,
         choices: {
             "default": "SETTING.INIT_DEFAULT",
-            "roll": "SETTING.INIT_ROLL"
+            "roll1d6": "SETTING.INIT_ROLL1d",
+            "roll2d6": "SETTING.INIT_ROLL2d"
         },
         onChange: rule => {
             switch (rule) {
                 case "default":
-                    CONFIG.Combat.initiative = { formula: "@combat.initiative.total", decimals: 0 };
+                    CONFIG.Combat.initiative = { formula: "1d0 + @combat.initiative.total", decimals: 0 };
                     break;
-                case "roll":
+                case "roll1d6":
+                    CONFIG.Combat.initiative = { formula: "1d6 + @combat.initiative.total", decimals: 0 };
+                    break;
+                case "roll2d6":
                     CONFIG.Combat.initiative = { formula: "2d6 + @combat.initiative.total", decimals: 0 };
                     break;
             }

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -19,6 +19,10 @@ export async function combatRoll(attribute, skill, combat, dn) {
     } else {
         damage = weapon.damage - combat.armour;
     }
+    
+    if(damage < 0) {
+        damage = 0;
+    }
     await _sendToChat(result, dn, skill.focus, damage, weapon.traits);
 }
 

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -3,14 +3,14 @@ export async function customRoll(pool, dn) {
     await _sendToChat(result, dn, 0, null, null);
 }
 
-export async function commonRoll(attribute, skill, dn) {
-    const numberOfDice = attribute.total + skill.total;
+export async function commonRoll(attribute, skill, bonusDice, dn) {
+    const numberOfDice = attribute.total + skill.total + bonusDice;
     let result = _roll(numberOfDice, dn);
     await _sendToChat(result, dn, skill.focus, null, null);
 }
 
-export async function combatRoll(attribute, skill, combat, dn) {
-    const numberOfDice = attribute.total + skill.total;
+export async function combatRoll(attribute, skill, bonusDice, combat, dn) {
+    const numberOfDice = attribute.total + skill.total + bonusDice;
     let result = _roll(numberOfDice, dn);
     let weapon = _getWeapon(combat.weapon);
     let damage;
@@ -26,8 +26,8 @@ export async function combatRoll(attribute, skill, combat, dn) {
     await _sendToChat(result, dn, skill.focus, damage, weapon.traits);
 }
 
-export async function powerRoll(attribute, skill, power, dn) {
-    const numberOfDice = attribute.total + skill.total;
+export async function powerRoll(attribute, skill, bonusDice, power, dn) {
+    const numberOfDice = attribute.total + skill.total + bonusDice;
     let result = _roll(numberOfDice, dn);
 	let effect = power.data.data.effect;
 	let resist = null;

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -33,8 +33,9 @@ export async function powerRoll(attribute, skill, power, dn) {
         overcast = power.data.data.overcast;
 		duration = power.data.data.duration;
 		resist = power.data.data.test;
-		if(resist !== null && result.success.length > 0) {
-			resist = resist.replace(/:s/ig, ":" + result.success.length - dn.complexity + 1);
+		let complexity = result.success.length - dn.complexity +1
+		if(resist !== null && complexity > 0) {
+			resist = resist.replace(/:s/ig, ":" + complexity);
 		}
 	}
     await _sendSpellToChat(result, dn, skill.focus, duration, overcast, effect, resist);

--- a/scripts/common/roll.js
+++ b/scripts/common/roll.js
@@ -1,12 +1,12 @@
 export async function customRoll(pool, dn) {
     let result = _roll(pool, dn);
-    await _sendToChat(result, dn, 0, null, null);
+    await _sendToChat(result, dn, 0, null, null, false);
 }
 
 export async function commonRoll(attribute, skill, bonusDice, dn) {
     const numberOfDice = attribute.total + skill.total + bonusDice;
     let result = _roll(numberOfDice, dn);
-    await _sendToChat(result, dn, skill.focus, null, null);
+    await _sendToChat(result, dn, skill.focus, null, null, false);
 }
 
 export async function combatRoll(attribute, skill, bonusDice, combat, dn) {
@@ -23,7 +23,7 @@ export async function combatRoll(attribute, skill, bonusDice, combat, dn) {
     if(damage < 0) {
         damage = 0;
     }
-    await _sendToChat(result, dn, skill.focus, damage, weapon.traits);
+    await _sendToChat(result, dn, skill.focus, damage, weapon.traits, true);
 }
 
 export async function powerRoll(attribute, skill, bonusDice, power, dn) {
@@ -37,7 +37,7 @@ export async function powerRoll(attribute, skill, bonusDice, power, dn) {
         overcast = power.data.data.overcast;
 		duration = power.data.data.duration;
 		resist = power.data.data.test;
-		let complexity = result.success.length - dn.complexity +1
+		let complexity = result.success.length - dn.complexity + 1 // complexity of spelltest is 1 + successes Core p.266 
 		if(resist !== null && complexity > 0) {
 			resist = resist.replace(/:s/ig, ":" + complexity);
 		}
@@ -91,11 +91,11 @@ async function _sendSpellToChat(result, dn, focus, duration, overcast, effect, r
     ChatMessage.create(chatData);
 }
 
-async function _sendToChat(result, dn, focus, damage, traits) {
+async function _sendToChat(result, dn, focus, damage, traits, isCombat) {
     const dices = result.success.concat(result.failed);
     const data = {
         hasSucceed: result.success.length >= dn.complexity,
-        success: result.success.length,
+        success: isCombat ? result.success.length : result.success.length - dn.complexity,
         missing: dn.complexity - result.success.length,
         failed: result.failed.length,
         dices: dices.sort(function (a, b) { return b - a; }),

--- a/scripts/sheet/actor.js
+++ b/scripts/sheet/actor.js
@@ -152,8 +152,8 @@ export class AgeOfSigmarActorSheet extends ActorSheet {
 
     _getCombat(weapon) {
         return {
-            melee: this.actor.data.data.combat.melee.total,
-            accuracy: this.actor.data.data.combat.accuracy.total,
+            melee: this.actor.data.data.combat.melee.relative,
+            accuracy: this.actor.data.data.combat.accuracy.relative,
             weapon: {
                 name: weapon.data.name,
                 category: weapon.data.data.category,

--- a/style/common/variable.css
+++ b/style/common/variable.css
@@ -6,6 +6,7 @@
 @font-face {
     font-family: "Alegreya Sans SC";
     src: url("../../asset/font/alegreya-sans-sc-bold.ttf");
+	font-weight: bold;
 }
 
 :root {

--- a/style/sheet/player.css
+++ b/style/sheet/player.css
@@ -12,6 +12,8 @@
     flex-basis: 100%;
 }
 
+
+
 .age-of-sigmar-soulbound.sheet.actor .player .sheet-header .avatar {
     border: 1px solid var(--color-border);
     box-shadow: inset 0 0 6px var(--color-border);
@@ -63,13 +65,9 @@
     margin-left: 5px;
 }
 
-.age-of-sigmar-soulbound.sheet.actor .player .sheet-header .bio .archetype {
-    display: flex;
-    flex-direction: row;
-    flex-basis: calc(50% - 5px);
-    margin-right: 5px;
-}
-
+.age-of-sigmar-soulbound.sheet.actor .player .sheet-header .bio .faction,
+.age-of-sigmar-soulbound.sheet.actor .player .sheet-header .bio .subfaction,
+.age-of-sigmar-soulbound.sheet.actor .player .sheet-header .bio .archetype,
 .age-of-sigmar-soulbound.sheet.actor .player .sheet-header .bio .species {
     display: flex;
     flex-direction: row;

--- a/style/sheet/tab/player-bio.css
+++ b/style/sheet/tab/player-bio.css
@@ -22,15 +22,15 @@
 }
 
 .age-of-sigmar-soulbound.sheet.actor .player .bio .physical .wrapper label {
-    width: 60px;
+    width: 70px;
 }
 
 .age-of-sigmar-soulbound.sheet.actor .player .bio .physical .wrapper input {
-    width: 73px;
+    width: 152px;
 }
 
 .age-of-sigmar-soulbound.sheet.actor .player .bio .physical .wrapper .age,
-.age-of-sigmar-soulbound.sheet.actor .player .bio .physical .wrapper .eyes,
+.age-of-sigmar-soulbound.sheet.actor .player .bio .physical .wrapper .eyeType,
 .age-of-sigmar-soulbound.sheet.actor .player .bio .physical .wrapper .hair,
 .age-of-sigmar-soulbound.sheet.actor .player .bio .physical .wrapper .height {
     display: flex;
@@ -39,6 +39,7 @@
     margin-right: 5px;
 }
 
+.age-of-sigmar-soulbound.sheet.actor .player .bio .physical .eyes,
 .age-of-sigmar-soulbound.sheet.actor .player .bio .physical .weight {
     display: flex;
     flex-direction: row;

--- a/template.json
+++ b/template.json
@@ -165,6 +165,7 @@
               "bonus": 0
             },
             "wounds": {
+              "value": 0,
               "bonus": 0
             }
           },
@@ -175,12 +176,15 @@
             "bonus": 0
           },
           "melee": {
+            "relative" : 0,
             "bonus": 0
           },
           "accuracy": {
+            "relative" : 0,
             "bonus": 0
           },
           "defense": {
+            "relative" : 0,
             "bonus": 0
           },
           "armour": {

--- a/template.json
+++ b/template.json
@@ -212,7 +212,8 @@
         "distinguishingFeatures": "",
         "background": "",
         "faction": "",
-        "subfaction": ""
+        "subfaction": "",
+        "eyeType": ""
       },
       "experience": 0,
       "notes": ""

--- a/template.json
+++ b/template.json
@@ -210,7 +210,9 @@
         "height": "",
         "weight": "",
         "distinguishingFeatures": "",
-        "background": ""
+        "background": "",
+        "faction": "",
+        "subfaction": ""
       },
       "experience": 0,
       "notes": ""

--- a/template/dialog/common-roll.html
+++ b/template/dialog/common-roll.html
@@ -28,6 +28,10 @@
         <input id="dn" type="text" value="4:2" />
     </div>
     <div class="wrapper">
+        <label>{{localize "DIALOG.BONUSDICE"}}</label>
+        <input id="bonusDice" type="number" value="{{bonusDice}}" />
+    </div>
+    <div class="wrapper">
         <label>{{localize "DIALOG.DOUBLE_TRAINING"}}</label>
         <input id="double-training" type="checkbox" value="active" />
     </div>

--- a/template/dialog/spell-roll.html
+++ b/template/dialog/spell-roll.html
@@ -24,28 +24,8 @@
         </select>
     </div>
     <div class="wrapper">
-        <label>{{localize "DIALOG.DEFENSE"}}</label>
-        {{#if defense.enabled}}
-        <select id="defense">
-        {{else}}
-        <select id="defense" disabled>
-        {{/if}}
-            {{#each defense.values as | defense |}}
-                {{#if defense.selected}}
-                    <option value="{{defense.key}}" selected>{{localize defense.label}} {{defense.key}}</option>
-                {{else}}
-                    <option value="{{defense.key}}">{{localize defense.label}} {{defense.key}}</option>
-                {{/if}}
-            {{/each}}
-        </select>
-    </div>
-    <div class="wrapper">
-        <label>{{localize "DIALOG.ARMOUR"}}</label>
-        {{#if armour.enabled}}
-            <input id="armour" type="number" value="{{armour.value}}"/>
-        {{else}}
-            <input id="armour" type="number" value="{{armour.value}}" disabled/>
-        {{/if}}
+        <label>{{localize "DIALOG.DN"}}</label>
+        <input id="dn" type="text" value="{{dn}}" />
     </div>
     <div class="wrapper">
         <label>{{localize "DIALOG.BONUSDICE"}}</label>

--- a/template/sheet/armour.html
+++ b/template/sheet/armour.html
@@ -30,8 +30,8 @@
                     <h1>{{localize "TITLE.STATS"}}</h1>
                     <div class="wrapper">
                         <label>{{localize "ARMOUR.TYPE"}}</label>
-                        <select name="data.category">
-                            {{#select data.category}}
+                        <select name="data.type">
+                            {{#select data.type}}
                                 <option value="light">{{localize "TYPE.LIGHT"}}</option>
                                 <option value="medium">{{localize "TYPE.MEDIUM"}}</option>
                                 <option value="heavy">{{localize "TYPE.HEAVY"}}</option>

--- a/template/sheet/player.html
+++ b/template/sheet/player.html
@@ -25,6 +25,16 @@
                         <input name="data.bio.species" type="text" value="{{data.bio.species}}"/>
                     </div>
                 </div>
+                <div class="wrapper-row">
+                    <div class="faction">
+                        <label>{{localize "BIO.FACTION"}}</label>
+                        <input name="data.bio.faction" type="text" value="{{data.bio.faction}}"/>
+                    </div>
+                    <div class="subfaction">
+                        <label>{{localize "BIO.SUBFACTION"}}</label>
+                        <input name="data.bio.subfaction" type="text" value="{{data.bio.subfaction}}"/>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/template/sheet/tab/npc-combat.html
+++ b/template/sheet/tab/npc-combat.html
@@ -21,17 +21,17 @@
                 <div class="melee">
                     <label>{{localize "HEADER.MELEE"}}</label>
                     <input name="data.combat.melee.bonus" type="number" value="{{data.combat.melee.bonus}}" data-dtype="Number" />
-                    <input type="text" value="{{combatAbilities data.combat.melee.total}}" disabled />
+                    <input type="text" value="{{combatAbilities data.combat.melee.relative}}" disabled />
                 </div>
                 <div class="accuracy">
                     <label>{{localize "HEADER.ACCURACY"}}</label>
                     <input name="data.combat.accuracy.bonus" type="number" value="{{data.combat.accuracy.bonus}}" data-dtype="Number" />
-                    <input type="text" value="{{combatAbilities data.combat.accuracy.total}}" disabled />
+                    <input type="text" value="{{combatAbilities data.combat.accuracy.relative}}" disabled />
                 </div>
                 <div class="defense">
                     <label>{{localize "HEADER.DEFENSE"}}</label>
                     <input name="data.combat.defense.bonus" type="number" value="{{data.combat.defense.bonus}}" data-dtype="Number" />
-                    <input type="text" value="{{combatAbilities data.combat.defense.total}}" disabled />
+                    <input type="text" value="{{combatAbilities data.combat.defense.relative}}" disabled />
                 </div>
                 <div class="armour">
                     <label>{{localize "HEADER.ARMOUR"}}</label>

--- a/template/sheet/tab/player-bio.html
+++ b/template/sheet/tab/player-bio.html
@@ -6,10 +6,16 @@
                 <label>{{localize "BIO.AGE"}}</label>
                 <input name="data.bio.age" type="text" value="{{data.bio.age}}"/>
             </div>
+            <div class="eyeType">
+                <label>{{localize "BIO.EYETYPE"}}</label>
+                <input name="data.bio.eyeType" type="text" value="{{data.bio.eyeType}}"/>
+            </div>
             <div class="eyes">
                 <label>{{localize "BIO.EYES"}}</label>
                 <input name="data.bio.eyes" type="text" value="{{data.bio.eyes}}"/>
             </div>
+        </div>
+        <div class="wrapper">
             <div class="hair">
                 <label>{{localize "BIO.HAIR"}}</label>
                 <input name="data.bio.hair" type="text" value="{{data.bio.hair}}"/>

--- a/template/sheet/tab/player-combat.html
+++ b/template/sheet/tab/player-combat.html
@@ -21,17 +21,17 @@
                 <div class="melee">
                     <label>{{localize "HEADER.MELEE"}}</label>
                     <input name="data.combat.melee.bonus" type="number" value="{{data.combat.melee.bonus}}" data-dtype="Number" />
-                    <input type="text" value="{{combatAbilities data.combat.melee.total}}" disabled />
+                    <input type="text" value="{{combatAbilities data.combat.melee.relative}}" disabled />
                 </div>
                 <div class="accuracy">
                     <label>{{localize "HEADER.ACCURACY"}}</label>
                     <input name="data.combat.accuracy.bonus" type="number" value="{{data.combat.accuracy.bonus}}" data-dtype="Number" />
-                    <input type="text" value="{{combatAbilities data.combat.accuracy.total}}" disabled />
+                    <input type="text" value="{{combatAbilities data.combat.accuracy.relative}}" disabled />
                 </div>
                 <div class="defense">
                     <label>{{localize "HEADER.DEFENSE"}}</label>
                     <input name="data.combat.defense.bonus" type="number" value="{{data.combat.defense.bonus}}" data-dtype="Number" />
-                    <input type="text" value="{{combatAbilities data.combat.defense.total}}" disabled />
+                    <input type="text" value="{{combatAbilities data.combat.defense.relative}}" disabled />
                 </div>
                 <div class="armour">
                     <label>{{localize "HEADER.ARMOUR"}}</label>


### PR DESCRIPTION
### Fixes

Armour and Shields didn't work correctly since the variable wasn't correctly set in the template. Thus everything was by default counted als light armour. 

The Shield benefit is given as  "Defence increases one step", but inserting 1 into the benefit didn't always raise defence by one step    Shields added the benefit value directly to the total.  To actually increase by one step the benefit would need to be set to 2. This is counter intuitive,  Shield benefit value is now doubled before being applied to represent a one step increase.

The D:N calculation when targeting enemies was off due to using total values instead of relative values corresponding to the combat ladder. This causes Target Numbers either to be too high or too low depending on the enemy targeted. To negate this problem a new field relative is added to the combat stats. Relative is set by comparing the total value for each of the 3 combat stats against the combat ladder. The lowest possible value is 1 representing the of rating poor, The highest possible value is 6 representing the rating extraordinary.  Comparing the relative combat values of actors always results in the correct target number.

The comparison for close combat used accuracy instead of melee to calculate test difficulty. This was also corrected

Fixed a problem with initiative not being correctly set during Gameworld initialisation, so a selected Initiative would not work after a World restart.

In the Character Sheets Bio Section was no field to enter ones Eye Type which can be rolled for during character creation using the table on Page 32 of the Core Rule Book. The Field was added and the existing fields reordered to account for this.

Champions of Order added sub-factions with unique benefits for players to choose from. The Field Faction and Sub-Faction where already present for NPCs. Players now also have access to those fields to record their chosen Faction and Sub-Faction

### New Features
With the fixes to combat calculations it was easy to to create a new Dialog for combat rolls and implement feature request 
ISSUE #4 . The field dn is replaced with dropdown menu to select the enemy defence rating. The default selection is the rating good. When using the target function the field is set to the targets defence rating and disabled. An input field for the targets armour rating is added to the combat dialog, Default for this field is zero. The input is automatically subtracted from the damage rolled. When using the target function this field is disabled and populated with the targets armour value. 

Certain Spells, Talents and Miracles grant Bonus Dice to certain Tests but there was no field to add those to test short of making a custom roll. To alleviate this all dialogs except the custom roll dialog now have a field "Bonus Dice" to increase or decrease the dice pool of a specific test
