### PR TITLE
Fixed armour field not working and chat template to post spells

### DIFF
--- a/scripts/common/actor.js
+++ b/scripts/common/actor.js
@@ -214,6 +214,7 @@ export class AgeOfSigmarActor extends Actor {
         this.combat.melee.total +=             this.attributes.body.value + this.skills.weaponSkill.total + (this.combat.melee.bonus * 2);
         this.combat.accuracy.total +=          this.attributes.mind.value + this.skills.ballisticSkill.total + (this.combat.accuracy.bonus * 2);
         this.combat.defense.total +=           this.attributes.body.total + this.skills.reflexes.total + (this.combat.defense.bonus * 2);
+        this.combat.armour.total +=            this.combat.armour.bonus;
         this.combat.health.toughness.max +=    this.attributes.body.total + this.attributes.mind.total + this.attributes.soul.total + this.combat.health.toughness.bonus;
         this.combat.health.wounds.max +=       Math.ceil((this.attributes.body.total + this.attributes.mind.total + this.attributes.soul.total) / 2) + this.combat.health.wounds.bonus;
         this.combat.health.wounds.deadly =     this.combat.health.wounds.value >= this.combat.health.wounds.max;

--- a/template/chat/item.html
+++ b/template/chat/item.html
@@ -61,7 +61,7 @@
         <p><strong>{{localize "SPELL.RANGE"}}:</strong> {{item.range}}</p>
         <p><strong>{{localize "SPELL.DURATION"}}:</strong> {{item.duration}}</p>
         <p><strong>{{localize "SPELL.TEST"}}:</strong> {{item.test}}</p>
-        <p><strong>{{localize "SPELL.OVERCAST"}}:</strong> {{item.duration}}</p>
+        <p><strong>{{localize "SPELL.OVERCAST"}}:</strong> {{item.overcast}}</p>
         <p><strong>{{localize "SPELL.DESCRIPTION"}}:</strong> {{{item.description}}}</p>
         {{/if}}
 


### PR DESCRIPTION
Chat template wrongly posted the value for duration in overcast as well as duration
When computing secondary stats the value from the bonus field was not added to total armour