### PR TITLE
Item dice pool calculation used the wrong attribute

### DIFF
--- a/scripts/common/actor.js
+++ b/scripts/common/actor.js
@@ -203,7 +203,7 @@ export class AgeOfSigmarActor extends Actor {
                 item.pool = this.attributes.body.total + this.skills.weaponSkill.total;
                 item.focus = this.skills.weaponSkill.focus;
             } else {
-                item.pool = this.attributes.mind.total + this.skills.ballisticSkill.total;
+                item.pool = this.attributes.body.total + this.skills.ballisticSkill.total;
                 item.focus = this.skills.ballisticSkill.focus;
             }
         })


### PR DESCRIPTION
Ranged dice pool used mind instead of body for ranged weapons. While Mind is used to determine accuracy, attacks are rolled using body + ballistic skill