### PR TITLE
Fixed Double Training and Double Focus changing skill values until actor is updated. Changed mettle to be available as a token bar

### DIFF
--- a/scripts/actor/actor-aos.js
+++ b/scripts/actor/actor-aos.js
@@ -51,7 +51,7 @@ export class AgeOfSigmarActor extends Actor {
         this.combat.health.wounds.max = 0;
         this.combat.initiative.total = 0;
         this.combat.naturalAwareness.total = 0;
-        this.combat.mettle.total = 0;
+        this.combat.mettle.max = 0;
         this.combat.damage = 0;
         this.power.consumed = 0,
         this.power.capacity = 0,
@@ -157,7 +157,7 @@ export class AgeOfSigmarActor extends Actor {
     _computeItemCombat(item) {
         let combat = item.bonus.combat
     
-        this.combat.mettle.total +=           combat.mettle;
+        this.combat.mettle.max +=             combat.mettle;
         this.combat.health.toughness.max +=   combat.health.toughness;
         this.combat.health.wounds.max +=      combat.health.wounds;
         this.combat.health.wounds.deadly =    this.combat.health.wounds.value >= this.combat.health.wounds.max;
@@ -229,7 +229,7 @@ export class AgeOfSigmarActor extends Actor {
         this.combat.defense.total +=           this.attributes.body.total + this.skills.reflexes.training + (this.combat.defense.bonus * 2);
         this.combat.armour.total +=            this.combat.armour.bonus;        
         this.combat.initiative.total +=        this.attributes.mind.total + this.skills.awareness.training + this.skills.reflexes.training + this.combat.initiative.bonus;
-        this.combat.naturalAwareness.total +=  Math.ceil((this.attributes.mind.training + this.skills.awareness.training) / 2) + this.combat.naturalAwareness.bonus;        
+        this.combat.naturalAwareness.total +=  Math.ceil((this.attributes.mind.total + this.skills.awareness.training) / 2) + this.combat.naturalAwareness.bonus;        
         this.power.isUndercharge =             this.power.consumed > this.power.capacity;
         
         if(this.autoCalc.toughness) {
@@ -244,7 +244,7 @@ export class AgeOfSigmarActor extends Actor {
         }
 
         if(this.autoCalc.mettle) {
-            this.combat.mettle.total += Math.ceil(this.attributes.soul.total / 2) + this.combat.mettle.bonus;
+            this.combat.mettle.max += Math.ceil(this.attributes.soul.total / 2) + this.combat.mettle.bonus;
         }
     }
 

--- a/scripts/system/dialog.js
+++ b/scripts/system/dialog.js
@@ -50,10 +50,10 @@ export async function prepareCommonRoll(skillKey, attributes, skills, attributeK
                     const doubleTraining = html.find("#double-training")[0].checked;
                     const doubleFocus = html.find("#double-focus")[0].checked;
                     const attribute = attributes[attributeName];
-                    let skill = skills[skillName];
+                    let skill = foundry.utils.deepClone(skills[skillName]); // we don't actually want to change the skill just use it.
                     const dn = _getDn(`${game.i18n.localize(attribute.label)} (${game.i18n.localize(skill.label)})`, html.find("#dn")[0].value);
-                    if (doubleTraining) skill.total = skill.total * 2;
-                    if (doubleFocus) skill.focus = skill.focus * 2;
+                    if (doubleTraining) skill.roll *= 2;
+                    if (doubleFocus) skill.focus *= 2;
                     let bonusDice = _getBonusDice(html);
                     await commonRoll(attribute, skill, bonusDice, dn);
                 },
@@ -107,13 +107,13 @@ export async function prepareCombatRoll(attributes, skills, combat) {
                     const doubleFocus = html.find("#double-focus")[0].checked;
                     const attribute = attributes[attributeName];
                     const rating = html.find("#attack")[0].value;
-                    let skill = skills[skillName];                    
+                    let skill = foundry.utils.deepClone(skills[skillName]);                    
                     targetDefense = html.find("#defense")[0].value;
                     combat.armour = html.find("#armour")[0].value;
                     const dn = _getDn(combat.weapon.name, _getCombatDn(rating, targetDefense));
-                    if (doubleTraining) skill.total = skill.total * 2;
-                    if (doubleFocus) skill.focus = skill.focus * 2;
-                    const bonusDice = _getBonusDice(html)
+                    if (doubleTraining) skill.roll *= 2;
+                    if (doubleFocus) skill.focus *= 2;
+                    const bonusDice = _getBonusDice(html);
                     await combatRoll(attribute, skill, bonusDice , combat, dn);
                 },
             },
@@ -155,10 +155,10 @@ export async function preparePowerRoll(skillKey, attributes, skills, power) {
                     const doubleTraining = html.find("#double-training")[0].checked;
                     const doubleFocus = html.find("#double-focus")[0].checked;
                     const attribute = attributes[attributeName];
-                    let skill = skills[skillName];
+                    let skill = foundry.utils.deepClone(skills[skillName]);
                     const dn = _getDn(power.data.name, html.find("#dn")[0].value);
-                    if (doubleTraining) skill.total = skill.total * 2;
-                    if (doubleFocus) skill.focus = skill.focus * 2;
+                    if (doubleTraining) skill.roll *= 2;
+                    if (doubleFocus) skill.focus *= 2;
                     const bonusDice = _getBonusDice(html)
                     await powerRoll(attribute, skill, bonusDice, power, dn);
                 },

--- a/template/dialog/combat-roll.html
+++ b/template/dialog/combat-roll.html
@@ -42,7 +42,7 @@
     </div>
     <div class="wrapper">
         <label>{{localize "DIALOG.ARMOUR"}}</label>
-            <input id="armour" type="number" value="{{armour}}"/>
+            <input id="armour" type="number" value="{{combat.armour}}"/>
     </div>
     <div class="wrapper">
         <label>{{localize "DIALOG.BONUSDICE"}}</label>

--- a/template/sheet/tab/npc-combat.html
+++ b/template/sheet/tab/npc-combat.html
@@ -85,7 +85,7 @@
                     <label>{{localize "HEADER.METTLE"}}</label>
                     <input name="data.combat.mettle.value" type="number" value="{{data.combat.mettle.value}}" data-dtype="Number" />
                     <input name="data.combat.mettle.bonus" type="number" value="{{data.combat.mettle.bonus}}" data-dtype="Number" />
-                    <input type="number" value="{{data.combat.mettle.total}}" data-dtype="Number" disabled />
+                    <input type="number" value="{{data.combat.mettle.max}}" data-dtype="Number" disabled />
                 </div>
                 <div class="wounds">
                     <label>{{localize "HEADER.WOUND"}}</label>

--- a/template/sheet/tab/player-combat.html
+++ b/template/sheet/tab/player-combat.html
@@ -81,7 +81,7 @@
                     <label>{{localize "HEADER.METTLE"}}</label>
                     <input name="data.combat.mettle.value" type="number" value="{{data.combat.mettle.value}}" data-dtype="Number" />
                     <input name="data.combat.mettle.bonus" type="number" value="{{data.combat.mettle.bonus}}" data-dtype="Number" />
-                    <input type="number" value="{{data.combat.mettle.total}}" data-dtype="Number" disabled />
+                    <input type="number" value="{{data.combat.mettle.max}}" data-dtype="Number" disabled />
                 </div>
                 <div class="wounds">
                     <label>{{localize "HEADER.WOUND"}}</label>


### PR DESCRIPTION
With the removal of the cloned skills and attributes in the actor sheet, the combat dialog functions to double training and focus would semi permanently increase the used skills derived values. The only way to reset the skill to it's correct values is to update the actor. Causing the field to be reevaluated. To counteract this, the selected skill is cloned for use in the following functions. Since we use most of the values of the skill object simply cloning it for modification and evaluation is better than creating a new object and filling it with the skill values.

So people can use mettle in the Token Bar the value mettle.total has been renamed to mettle.max. 