### PR TITLE
Fix Swarm Max Toughness not Editable and stuck at 0

### DIFF
--- a/scripts/actor/actor-aos.js
+++ b/scripts/actor/actor-aos.js
@@ -103,7 +103,8 @@ export class AgeOfSigmarActor extends Actor {
         this.combat.defence.total = 0;
         this.combat.defence.relative = 0;
         this.combat.armour.value = 0;
-        this.combat.health.toughness.max = 0;        
+        if(!this.isSwarm) //Wenn set to Swarm max is editable don't reset it
+            this.combat.health.toughness.max = 0;        
         this.combat.health.wounds.value = 0;
         this.combat.health.wounds.max = 0;
         this.combat.initiative.total = 0;
@@ -234,7 +235,9 @@ export class AgeOfSigmarActor extends Actor {
         
         if(this.autoCalc.toughness) {
             this.combat.health.toughness.max += this.attributes.body.value + this.attributes.mind.value + this.attributes.soul.value + this.combat.health.toughness.bonus;
-        } else if(!this.isSwarm) {
+        } else if(this.isSwarm) {
+            this.combat.health.toughness.max += this.combat.health.toughness.bonus;            
+        } else {
             this.combat.health.toughness.max = 1;
         }
         

--- a/template/sheet/tab/player-combat.html
+++ b/template/sheet/tab/player-combat.html
@@ -25,7 +25,16 @@
         <div class="entry-vertical">
             <h3>{{localize "HEADER.TOUGHNESS"}}</h3>
             <div class="segment-horizontal">
-                <div class="sheet-table-valueMain"><input name="data.combat.health.toughness.value" type="number" value="{{data.combat.health.toughness.value}}" data-dtype="Number" /></div> / <div class="sheet-table-valueMain"><input type="number" value="{{data.combat.health.toughness.max}}" data-dtype="Number" disabled /></div>
+                <div class="sheet-table-valueMain">
+                    <input name="data.combat.health.toughness.value" type="number" value="{{data.combat.health.toughness.value}}" data-dtype="Number" />
+                </div> / 
+                <div class="sheet-table-valueMain">
+                    {{#unless (eq data.bio.type 0)}}
+                        <input type="number" value="{{data.combat.health.toughness.max}}" data-dtype="Number" disabled />
+                    {{else}}
+                        <input name="data.combat.health.toughness.max" type="number" value="{{data.combat.health.toughness.max}}" data-dtype="Number" />
+                    {{/unless}}
+                </div>
             </div>
             <div class="segment-horizontal">{{localize "HEADER.BONUS"}}: <div class="sheet-table-value"><input name="data.combat.health.toughness.bonus" type="number" value="{{data.combat.health.toughness.bonus}}" data-dtype="Number" /></div></div>
         </div>


### PR DESCRIPTION
Swarms are unique as they respresent several minions in a single package. The Toughness Value dictates how many are in the swarm due to Minions having only one health. Since the GM defines how many creatures are in the swarm he should be able to define their number. For that the Toughness Max Field is made editiable in case of a swarm.

In the current Version for Swarms the Toughness Max Value was stuck at 0 zero due to being always initialized at zero wich would override user input. User input was also not possible because that feature got lost when the redundant npc pages where removed