### PR TITLE
fix: create new hotbar macro if user has bo privileges to run one that exists

### DIFF
--- a/scripts/system/hooks.js
+++ b/scripts/system/hooks.js
@@ -158,7 +158,8 @@ export default function registerHooks() {
         if (document.documentName == "Item") {
             let command = `game.macro.rollItemMacro("${document.name}", "${document.type}");`;
             macro = game.macros.contents.find(m => (m.name === document.name) && (m.command === command));
-            if (!macro) {
+
+            if (!macro || !macro.canExecute) {
                 macro = await Macro.create({
                     name: document.name,
                     type: "script",


### PR DESCRIPTION
As mentioned in #179 simple solution to silently create a new macro if one for the same item and type exists but user has no privileges to run it