### PR TITLE
Fix Toughness & Wound not being usable for token bar attribute

### DIFF
--- a/scripts/model/actor/components/combat.js
+++ b/scripts/model/actor/components/combat.js
@@ -15,12 +15,12 @@ export class StandardCombatModel extends foundry.abstract.DataModel
         schema.health = new fields.SchemaField({
             toughness : new fields.SchemaField({
                 value : new fields.NumberField({initial: 0, min: 0}),
-                max : new fields$i.NumberField({initial: 0, min: 0}),
+                max : new fields.NumberField({initial: 0, min: 0}),
                 bonus : new fields.NumberField({initial : 0})
             }),
             wounds : new fields.SchemaField({
                 value : new fields.NumberField({initial: 0, min: 0}),
-                max : new fields$i.NumberField({initial: 0, min: 0}),
+                max : new fields.NumberField({initial: 0, min: 0}),
                 bonus : new fields.NumberField({initial: 0})
             })
         });

--- a/scripts/model/actor/components/combat.js
+++ b/scripts/model/actor/components/combat.js
@@ -15,10 +15,12 @@ export class StandardCombatModel extends foundry.abstract.DataModel
         schema.health = new fields.SchemaField({
             toughness : new fields.SchemaField({
                 value : new fields.NumberField({initial: 0, min: 0}),
+                max : new fields$i.NumberField({initial: 0, min: 0}),
                 bonus : new fields.NumberField({initial : 0})
             }),
             wounds : new fields.SchemaField({
-                // value : new fields.NumberField({initial: 0, min: 0}),
+                value : new fields.NumberField({initial: 0, min: 0}),
+                max : new fields$i.NumberField({initial: 0, min: 0}),
                 bonus : new fields.NumberField({initial: 0})
             })
         });


### PR DESCRIPTION
Since [6.1.0](https://github.com/moo-man/AoS-Soulbound-FoundryVTT/releases/tag/6.1.0), you can't select Toughness & Wounds as Token bar attribute.
Tokens created before [6.1.0](https://github.com/moo-man/AoS-Soulbound-FoundryVTT/releases/tag/6.1.0) with Toughness & Wounds as attribute are still working even if the UI doesn't show the attribute used.

This bug seems to happen because the field `max` isn't set on the new  `CombatModel` so Foundry doesn't recognize it as `Attribute Bar`, only as `Single Values`.

_I am not familiar with this new way of data model handling from Foundry. So maybe there is some thing missing to properly fix this issue._

**Before** the fix :
![Before the fix](https://github.com/moo-man/AoS-Soulbound-FoundryVTT/assets/5683489/04c63f85-4b26-43e8-9ea1-b857cf582814)


**After** the fix :
![After the fix](https://github.com/moo-man/AoS-Soulbound-FoundryVTT/assets/5683489/d90291c8-28a1-40fa-af5b-b1a26be40f19)
