### PR TITLE
Update combat-test.js remove doubled up Swarmdice 

### DIFF
--- a/scripts/apps/roll-dialog/combat.js
+++ b/scripts/apps/roll-dialog/combat.js
@@ -128,8 +128,6 @@ export class CombatRollDialog extends CommonRollDialog {
             swarmDice: actor.type === "npc" && actor.isSwarm ? actor.system.combat.health.toughness.value : 0,
         }
 
-        fields.bonusDice = data.combat.swarmDice;
-
         fields.attack = weapon.system.isMelee ? actor.system.combat.melee.relative : actor.system.combat.accuracy.relative
 
         data.showDualWielding = actor.items.filter(i => i.isAttack && i.equipped).length >= 2;

--- a/scripts/apps/roll-dialog/combat.js
+++ b/scripts/apps/roll-dialog/combat.js
@@ -128,6 +128,8 @@ export class CombatRollDialog extends CommonRollDialog {
             swarmDice: actor.type === "npc" && actor.isSwarm ? actor.system.combat.health.toughness.value : 0,
         }
 
+        fields.bonusDice = data.combat.swarmDice;
+        
         fields.attack = weapon.system.isMelee ? actor.system.combat.melee.relative : actor.system.combat.accuracy.relative
 
         data.showDualWielding = actor.items.filter(i => i.isAttack && i.equipped).length >= 2;

--- a/scripts/system/tests/combat-test.js
+++ b/scripts/system/tests/combat-test.js
@@ -169,7 +169,7 @@ export default class CombatTest extends SoulboundTest {
 
     get numberOfDice()
     {
-        return super.numberOfDice + this.testData.combat.swarmDice
+        return super.numberOfDice
     }
 
     get isDualWielding() 


### PR DESCRIPTION
Prevents the Bonus Dice from Swarm Rules being counted twice once from the Bonus Dice Field and combast.swarmDice Field when Rolling an Attack
Fixes #202 