### PR TITLE
Fix rolling with a target

### DIFF
--- a/scripts/system/tests/test.js
+++ b/scripts/system/tests/test.js
@@ -19,7 +19,7 @@ export default class SoulboundTest extends WarhammerTestBase {
             },
             context : {
                 speaker : data.speaker,
-                targetSpeakers : data.targets.map(t => t.actor.speakerData(t))|| [],
+                targetSpeakers : data.targets || [],
                 rollClass : this.constructor.name,
                 focusAllocated : false,
                 messageId : undefined,


### PR DESCRIPTION
Fixes #204

- Separates the `token` vs `this.isToken` branches of `speakerData` to ensure no `||` fallback to a invalid branch.
- Gets rid of unnecessary and incorrect `.document` call on `token`.
- Removes double-computation of `data.targets` in `SoulboundTest` constructor.

<img width="727" alt="Screenshot 2024-12-22 at 5 21 03 PM" src="https://github.com/user-attachments/assets/c1ebab88-2f0e-400b-8240-409a9c59448b" />
