### PR TITLE
Allow swarms to have any amount of health

### DIFF
--- a/scripts/model/actor/components/combat.js
+++ b/scripts/model/actor/components/combat.js
@@ -100,6 +100,9 @@ export class StandardCombatModel extends foundry.abstract.DataModel
             this.health.toughness.max = 1;
         }
         this.health.toughness.max += this.health.toughness.bonus;
+        if (this.parent.isSwarm) {
+            this.health.toughness.max = Number.MAX_VALUE;
+        }
         
         if(this.parent.autoCalc.wounds) 
         {


### PR DESCRIPTION
Currently, making any change to a swarm's health from the on-scene token controls sets it to zero, due to `Math.min` with a max health of zero. This sets their maximum health to be maxnum.

I'm not familiar with this codebase, so I'm not sure if there are some undesirable effects lurking somewhere subtle here. The UX also isn't great, e.g. the health bar will always be full and there's no way to easily tell at-a-glance how big the swarm is. But I think it's likely at least an improvement on the old behaviour, where you had to go in and make an absolute edit to the swarm toughness from the character sheet.